### PR TITLE
Docker 시혁

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,4 @@
 FROM mysql:8.2.0
-
+COPY config/. /etc/mysql/conf.d
+COPY init/. /docker-entrypoint-initdb.d
 ENV TZ=Asia/Seoul

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,9 +9,6 @@ services:
     environment:
       - MYSQL_DATABASE=sebadog_dev_db
       - MYSQL_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
-    volumes:
-      - ./database/config:/etc/mysql/conf.d
-      - ./database/init:/docker-entrypoint-initdb.d
     ports:
       - "3308:3308"
   sebadog-app:


### PR DESCRIPTION
- 기존에는 이미지를 run할 때, 로컬에 있는 파일을 명령어로 mount 하고 있음
       - 각자 매번 볼륨 파일을 로컬에 받고, 업데이트 해줘야 함.
       - 서버 코드를 받지 않고, 통합 테스트를 진행하고 싶지만 현재는 볼륨파일을 받기 위해 코드를 받아야 함.
       - 따라서 처음 이미지를 빌드할 때 볼륨 파일을 설정할 수 있도록 코드 개선

- 현재는 서버를 받을 필요도 없고, 볼륨을 설정하지 않아도 됨


[도커 실행 문서 참고](https://www.notion.so/Docker-Docker-7c3ca9476f5248f19449ee1df47222ce?pvs=4)